### PR TITLE
Added fsl binary install and other 3rd party R packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ADD package_installs.R /tmp/package_installs.R
 RUN apt-get update && \
     apt-get install -y -f libv8-dev libgeos-dev libgdal-dev libproj-dev \
     libtiff5-dev libfftw3-dev libjpeg-dev libhdf4-0-alt libhdf4-alt-dev \
-    libhdf5-dev libx11-dev && \
+    libhdf5-dev libx11-dev cmake libglu1-mesa-dev && \
     # data.table added here because rcran missed it, and xgboost needs it
     install2.r --error --repo http://cran.rstudio.com \
 	DiagrammeR \
@@ -55,6 +55,16 @@ RUN Rscript /tmp/bioconductor_installs.R && \
     mkdir -p /root/.jupyter/kernels && \
     cp -r /root/.local/share/jupyter/kernels/ir /root/.jupyter/kernels && \
     touch /root/.jupyter/jupyter_nbconvert_config.py && touch /root/.jupyter/migrated
+
+#FSL installation
+RUN wget -O- http://neuro.debian.net/lists/jessie.us-ca.full | tee /etc/apt/sources.list.d/neurodebian.sources.list && \
+    apt-key adv --recv-keys --keyserver hkp://pgp.mit.edu:80 0xA5D32F012649A5A9 && \
+    apt-get update && \
+    apt-get -y install fsl popularity-contest- && \
+    echo 'FSLDIR="/usr/share/fsl/5.0"' >> ~/.bashrc && \
+    echo '. ${FSLDIR}/etc/fslconf/fsl.sh' >> ~/.bashrc  && \
+    echo 'PATH=${FSLDIR}/bin:${PATH}' >> ~/.bashrc && \ 
+    echo 'export FSLDIR PATH'
 
 CMD ["R"]
 

--- a/package_installs.R
+++ b/package_installs.R
@@ -22,3 +22,12 @@ install.packages("openNLPmodels.en",
 install_github("davpinto/fastknn")
 install_github("mukul13/rword2vec")
 
+#Packages for Neurohacking in R coursera course
+install.packages("oro.nifti")
+install.packages("oro.dicom")
+devtools::install_github("muschellij2/fslr")
+devtools::install_github("stnava/ITKR")
+devtools::install_github("stnava/ANTsR")
+devtools::install_github("muschellij2/extrantsr")
+
+


### PR DESCRIPTION
Hi,

I created the dataset:https://www.kaggle.com/ilknuricke/neurohackinginrimages the other day in order to implement the code from the coursera course Neurohacking in R (https://www.coursera.org/learn/neurohacking). I quickly realized that some additional packages were needed to run some of the code on Kaggle's  R notebooks environment.

This docker builds and runs successfully on my mac. If these could be incorporated into Kaggle, I believe it would make it much easier for the participants of that Coursera course to work on the stuff without having to install R or any of the packages themselves.

Thank you in advance,
Ilknur Icke