### PR TITLE
Add lightGBM to Kernel image

### DIFF
--- a/package_installs.R
+++ b/package_installs.R
@@ -13,6 +13,7 @@ install_github("elbamos/largevis", ref="develop")  # Using development branch fo
 install_github("dgrtwo/widyr")
 install_github("ellisp/forecastxgb-r-package/pkg")
 install_github("rstudio/leaflet")
+install_github("Microsoft/LightGBM", subdir = "R-package")
 
 install.packages("genderdata", repos = "http://packages.ropensci.org")
 


### PR DESCRIPTION
Microsoft's lightGBM is not available on CRAN yet so it needs to be loaded through the repo on github.