### PR TITLE
Install the latest stable version of H2O

### DIFF
--- a/package_installs.R
+++ b/package_installs.R
@@ -17,8 +17,6 @@ install_github("hrbrmstr/hrbrthemes")
 
 install.packages("genderdata", repos = "http://packages.ropensci.org")
 
-install.packages("h2o", type="source", repos=(c("http://h2o-release.s3.amazonaws.com/h2o/latest_stable_R"))) # install the latest stable version of h2o
-
 install.packages("openNLPmodels.en",
                  repos = "http://datacube.wu.ac.at/",
                  type = "source")
@@ -34,4 +32,5 @@ devtools::install_github("stnava/ITKR")
 devtools::install_github("stnava/ANTsR")
 devtools::install_github("muschellij2/extrantsr")
 
+install.packages("h2o", type="source", repos=(c("http://h2o-release.s3.amazonaws.com/h2o/latest_stable_R"))) # install the latest stable version of h2o
 

--- a/package_installs.R
+++ b/package_installs.R
@@ -17,6 +17,8 @@ install_github("hrbrmstr/hrbrthemes")
 
 install.packages("genderdata", repos = "http://packages.ropensci.org")
 
+install.packages("h2o", type="source", repos=(c("http://h2o-release.s3.amazonaws.com/h2o/latest_stable_R"))) # install the latest stable version of h2o
+
 install.packages("openNLPmodels.en",
                  repos = "http://datacube.wu.ac.at/",
                  type = "source")


### PR DESCRIPTION
The docker currently uses the version of H2O that is on CRAN which is sometimes a few versions behind. This will install the latest stable version of H2O.