### PR TITLE
Ensure gganimate works.

### DIFF
--- a/build
+++ b/build
@@ -18,9 +18,10 @@ mkdir -p /tmp/rstats-build/devshm
 mkdir -p /tmp/rstats-build/working
 docker run --rm -t --read-only --net=none -e HOME=/tmp -v $PWD:/input:ro -v /tmp/rstats-build/working:/working -w=/working -v /tmp/rstats-build/tmp:/tmp -v /tmp/rstats-build/devshm:/dev/shm kaggle/rstats-build /bin/bash -c 'Rscript /input/test_build.R'
 
-# The test_build.R script creates plots called plot1.png and Rplot001.png; check that they exist
+# Verify expected test_build.R output is present.
 [ -s /tmp/rstats-build/working/plot1.png ] || exit 1
 [ -s /tmp/rstats-build/working/Rplot001.png ] || exit 1
+[ -s /tmp/rstats-build/working/plot2.gif ] || exit 1
 
 docker tag kaggle/rstats-build:latest kaggle/rstats:latest
 docker push kaggle/rstats:latest

--- a/test_build.R
+++ b/test_build.R
@@ -6,6 +6,8 @@ Library <- function(libname){
 }
 
 Library("Rcpp")
+Library("gapminder")
+Library("gganimate")
 Library("ggplot2")
 Library("stringr")
 Library("plyr")
@@ -30,10 +32,17 @@ Library("tidyr")
 Library("randomForest")
 Library("xgboost")
 
-testPlot <- ggplot(data.frame(x=1:10,y=runif(10))) + aes(x=x,y=y) + geom_line()
-ggsave(testPlot, filename="plot1.png")
+testPlot1 <- ggplot(data.frame(x=1:10,y=runif(10))) + aes(x=x,y=y) + geom_line()
+ggsave(testPlot1, filename="plot1.png")
 
 # Test that base graphics will save to .png by default
 plot(runif(10))
+
+# Test gganimate.
+testPlot2 <- ggplot(gapminder, aes(gdpPercap, lifeExp, size = pop, color = continent, frame = year)) +
+  geom_point() +
+  scale_x_log10()
+gganimate(testPlot2, "plot2.gif")
+
 
 print("Ok!")


### PR DESCRIPTION
This added test depends on ImageMagick's `convert` utility (and perhaps more) to
be installed.  That dependency is expected to be satisfied by `kaggle/rcran`.