### PR TITLE
lightgbm master is broken, pin to latest stable version

### DIFF
--- a/package_installs.R
+++ b/package_installs.R
@@ -14,7 +14,8 @@ install_github("elbamos/largevis", ref="develop")  # Using development branch fo
 install_github("dgrtwo/widyr")
 install_github("ellisp/forecastxgb-r-package/pkg")
 install_github("rstudio/leaflet")
-install_github("Microsoft/LightGBM", subdir = "R-package")
+# Build is failing on master with "Copying CMakeLists failed" error
+install_github("Microsoft/LightGBM@v2.1.2", subdir = "R-package")
 install_github("hrbrmstr/hrbrthemes")
 install_github('catboost/catboost', subdir = 'catboost/R-package')
 install_github("sassalley/hexmapr")

--- a/test_build.R
+++ b/test_build.R
@@ -39,6 +39,7 @@ Library("prophet")
 Library("fftw")
 Library("seewave")
 Library("mxnet")
+Library("lightgbm")
 
 testPlot1 <- ggplot(data.frame(x=1:10,y=runif(10))) + aes(x=x,y=y) + geom_line()
 ggsave(testPlot1, filename="plot1.png")


### PR DESCRIPTION
Fails installing on master:

```
Sep 20 12:48:15   --quiet CMD INSTALL  \
Sep 20 12:48:15   '/tmp/RtmpXvHCeI/devtools5485220c7ee2/Microsoft-LightGBM-425503d/R-package'  \
Sep 20 12:48:15   --library='/usr/local/lib/R/site-library' --install-tests 
Sep 20 12:48:15 
Sep 20 12:48:15 [0m[91m* installing *source* package 'lightgbm' ...
Sep 20 12:48:15 [0m[91m** libs
Sep 20 12:48:15 [0mgcc -I/usr/local/lib/R/include -DNDEBUG   -I/usr/local/include   -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c R_init.c -o R_init.o
Sep 20 12:48:15 gcc -shared -L/usr/local/lib/R/lib -L/usr/local/lib -o lightgbm.so R_init.o -L/usr/local/lib/R/lib -lR
Sep 20 12:48:15 [91minstalling via 'install.libs.R' to /usr/local/lib/R/site-library/lightgbm
Sep 20 12:48:15 [0m[91mError in eval(ei, envir) : Copying CMakeLists failed
Sep 20 12:48:15 [0m[91m* removing '/usr/local/lib/R/site-library/lightgbm'
```

Installing the latest stable version