### PR TITLE
Remove version pinning for LSHR

### DIFF
--- a/package_installs.R
+++ b/package_installs.R
@@ -18,9 +18,7 @@ install_github("rstudio/leaflet")
 install_url('https://github.com/catboost/catboost/releases/download/v0.12.1.1/catboost-R-Linux-0.12.1.1.tgz', args = c("--no-multiarch"))
 install_github("sassalley/hexmapr")
 install_github("hadley/multidplyr")
-# master is broken, I opened a PR on the package to fix it. Remove the commit hash below once merged.
-# https://github.com/dselivanov/LSHR/pull/14
-install_github("dselivanov/LSHR@f1d5c954393f84a0f9df5f6d96da8432b33d8594")
+install_github("dselivanov/LSHR")
 
 # install latest sparklyr and Spark (for local mode)
 install_github("rstudio/sparklyr")


### PR DESCRIPTION
My PR to fix an upstream bug has been merged:
https://github.com/dselivanov/LSHR/pull/14