### PR TITLE
Revert "Remove version pinning for LSHR"

### DIFF
--- a/package_installs.R
+++ b/package_installs.R
@@ -19,7 +19,7 @@ install_url('https://github.com/catboost/catboost/releases/download/v0.12.1.1/ca
 install_github("sassalley/hexmapr")
 install_github("hadley/multidplyr")
 # master is broken, I opened a PR on the package to fix it. Remove the commit hash below once merged.
-# https://github.com/dselivanov/LSHR/pull/14
+# https://github.com/dselivanov/LSHR/pull/15
 install_github("dselivanov/LSHR@f1d5c954393f84a0f9df5f6d96da8432b33d8594")
 
 # install latest sparklyr and Spark (for local mode)

--- a/package_installs.R
+++ b/package_installs.R
@@ -18,7 +18,9 @@ install_github("rstudio/leaflet")
 install_url('https://github.com/catboost/catboost/releases/download/v0.12.1.1/catboost-R-Linux-0.12.1.1.tgz', args = c("--no-multiarch"))
 install_github("sassalley/hexmapr")
 install_github("hadley/multidplyr")
-install_github("dselivanov/LSHR")
+# master is broken, I opened a PR on the package to fix it. Remove the commit hash below once merged.
+# https://github.com/dselivanov/LSHR/pull/14
+install_github("dselivanov/LSHR@f1d5c954393f84a0f9df5f6d96da8432b33d8594")
 
 # install latest sparklyr and Spark (for local mode)
 install_github("rstudio/sparklyr")


### PR DESCRIPTION
This reverts commit f70e4887e293fb6162e5bbb1e74991987753ac70.

Requires one more PR to get merged before we can install from master: https://github.com/dselivanov/LSHR/pull/15