### PR TITLE
Remove only dangling images between test run.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
         slackSend color: 'none', message: "*<${env.BUILD_URL}console|${JOB_NAME} docker build>* ${GIT_COMMIT_SUMMARY}", channel: env.SLACK_CHANNEL
         sh '''#!/bin/bash
           set -exo pipefail
-          docker image prune -a -f # remove previously built image to prevent disk from filling up
+          docker image prune -f # remove previously built image to prevent disk from filling up
           ./build --gpu | ts
         '''
       }


### PR DESCRIPTION
To avoid conflicts between the `docker-stats` and the `docker-python` pipeline.