### PR TITLE
Fix mxnet build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get update && \
 
 RUN Rscript /tmp/bioconductor_installs.R && \
     apt-get update && apt-get install -y libatlas-base-dev libopenblas-dev libopencv-dev && \
-    cd /usr/local/src && git clone --recursive --depth=1 --branch 1.3.0.rc0 https://github.com/apache/incubator-mxnet.git mxnet && \
+    cd /usr/local/src && git clone --recursive --depth=1 --branch v1.4.x https://github.com/apache/incubator-mxnet.git mxnet && \
     cd mxnet && make -j 4 USE_OPENCV=1 USE_BLAS=openblas && make rpkg && \
     # Needed for "h5" library
     apt-get install -y libhdf5-dev


### PR DESCRIPTION
Fixes:

```
Mar 04 15:10:57 �[91mCloning into 'mxnet'...
Mar 04 15:10:57 �[0m�[91mwarning: Could not find remote branch 1.3.0.rc0 to clone.
Mar 04 15:10:57 fatal: Remote branch 1.3.0.rc0 not found in upstream origin
The command '/bin/sh -c Rscript /tmp/bioconductor_installs.R &&     apt-get update && apt-get install -y libatlas-base-dev libopenblas-dev libopencv-dev &&     cd /usr/local/src && git clone --recursive --depth=1 --branch 1.3.0.rc0 https://github.com/apache/incubator-mxnet.git mxnet &&     cd mxnet && make -j 4 USE_OPENCV=1 USE_BLAS=openblas && make rpkg &&     apt-get install -y libhdf5-dev' returned a non-zero code: 128
```

v1.3.x is probably closer to what we used to have. However, v1.4.x reflects the
latest 1.4.0 release and passes our tests.