### PR TITLE
Add greta (greta-stats.org)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN apt-get install -y libzmq3-dev python-pip default-jdk && \
 # Keras sets up a virtualenv and installs tensorflow
 # in the WORKON_HOME directory, so choose an explicit location for it.
 ENV WORKON_HOME=/usr/local/share/.virtualenvs
-RUN pip install --user virtualenv && R -e 'keras::install_keras()'
+RUN pip install --user virtualenv && R -e 'keras::install_keras(extra_packages = "tensorflow-probability")'
 
 # Install kaggle libraries.
 # Do this at the end to avoid rebuilding everything when any change is made.

--- a/package_installs.R
+++ b/package_installs.R
@@ -48,3 +48,6 @@ install.packages("prophet")
 # handled in this image's Dockerfile.
 install.packages("fftw")
 install.packages("seewave")
+
+# Install greta development version (stable version requires older version of tensorflow)
+install.packages("greta-dev/greta")


### PR DESCRIPTION
[greta](https://greta-stats.org/index.html) is an library for statistical modeling in R. It requires **tensorflow-probability**, so I have added both.

[Installing it via custom packages](https://stackoverflow.com/a/55712007/3395716) is complex, and doesn't seem to work for development version. This pull request should make it much easier to use greta( by just loading it).

Also, hopefully this makes it possible to use GPU with greta :)