### PR TITLE
Remove baseballr package

### DIFF
--- a/package_installs.R
+++ b/package_installs.R
@@ -8,7 +8,6 @@ install_github("hadley/ggplot2")    # ggthemes is built against the latest ggplo
 install_github("jrnold/ggthemes")
 install_github("thomasp85/ggraph")
 install_github("thomasp85/gganimate")
-install_github("BillPetti/baseballr")
 install_github("elbamos/largevis")  # The package was removed from R CRAN: https://cran.r-project.org/web/packages/largeVis/index.html
 install_github("dgrtwo/widyr")
 install_github("ellisp/forecastxgb-r-package/pkg")


### PR DESCRIPTION
Installation failed because of dependent package:

```
Nov 27 21:28:58 [91mERROR: lazy loading failed for package ‘pitchRx’
Nov 27 21:28:58 [0m[91m* removing ‘/usr/local/lib/R/site-library/pitchRx’
Nov 27 21:28:58 [0m[91mError: Failed to install 'baseballr' from GitHub:
Nov 27 21:28:58   (converted from warning) installation of package ‘pitchRx’ had non-zero exit status
Nov 27 21:28:58 Execution halted
The command '/bin/sh -c Rscript /tmp/package_installs.R' returned a non-zero code: 1
```

Users can use the following to install it in their own kernel (when master is fixed or picking a known good commit):

```
library(devtools)
install_github("BillPetti/baseballr", force = TRUE)
```