### PR TITLE
Install IRkernel properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get install -y libzmq3-dev python-pip default-jdk && \
     # the latest version also has a regression on the NotebookApp.ip option
     # see: https://www.google.com/url?q=https://github.com/jupyter/notebook/issues/3946&sa=D&usg=AFQjCNFieP7srXVWqX8PDetXGfhyxRmO4Q
     pip install notebook==5.5.0 && \
+    R -e 'install.packages("IRkernel")' && \
     R -e 'IRkernel::installspec()' && \
     # Build pyzmq from source instead of using a pre-built binary.
     yes | pip uninstall pyzmq && \


### PR DESCRIPTION
https://irkernel.github.io/installation/

It was failing with this message: 
```
Feb 20 18:18:18 > IRkernel::installspec()
Feb 20 18:18:18 [91mError in loadNamespace(name) : there is no package called ‘IRkernel’
```