### PR TITLE
Set GITHUB_PAT env var from Jenkins credentials store

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,8 @@ pipeline {
     GIT_COMMIT_AUTHOR = sh(returnStdout: true, script:"git log --format='%an' -n 1 HEAD").trim()
     GIT_COMMIT_SUMMARY = "`<https://github.com/Kaggle/docker-rstats/commit/${GIT_COMMIT}|${GIT_COMMIT_SHORT}>` ${GIT_COMMIT_SUBJECT} - ${GIT_COMMIT_AUTHOR}"
     SLACK_CHANNEL = sh(returnStdout: true, script: "if [[ \"${GIT_BRANCH}\" == \"master\" ]]; then echo \"#kernelops\"; else echo \"#builds\"; fi").trim()
+    // See b/152450512
+    GITHUB_PAT = credentials('github-pat')
   }
 
   stages {


### PR DESCRIPTION
This will increase our GitHub rate limit from 60 calls / hour to 5000 calls / hour.

The token has a single permission:

* read public repo

This will increase our rate limit to avoid build failures like:

```
Mar 26 01:01:39  [0m [91mError: Failed to install 'unknown package' from GitHub:
Mar 26 01:01:39   HTTP error 403.
Mar 26 01:01:39   API rate limit exceeded for 35.231.143.114. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
Mar 26 01:01:39 
Mar 26 01:01:39   Rate limit remaining: 0/60
Mar 26 01:01:39   Rate limit reset at: 2020-03-26 01:46:37 UTC
```

BUG=152450512