### PR TITLE
Add --base-image-tag to build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM gcr.io/kaggle-images/rcran
+ARG BASE_TAG=latest
+
+FROM gcr.io/kaggle-images/rcran:${BASE_TAG}
 ARG ncpus=1
 
 ADD clean-layer.sh  /tmp/clean-layer.sh

--- a/build
+++ b/build
@@ -8,6 +8,7 @@ Build a new Docker R image.
 Options:
     -c, --use-cache Use layer cache when building a new image.
     -g, --gpu       Build an image with GPU support.
+    -b, --base-image-tag TAG  Base image tag. Defaults to value defined in DOCKERFILE.
 EOF
 }
 
@@ -15,6 +16,7 @@ CACHE_FLAG='--no-cache'
 DOCKERFILE='Dockerfile'
 IMAGE_TAG='kaggle/rstats-build'
 NCPUS=$(nproc || echo 1)
+BUILD_ARGS=''
 
 while :; do
     case "$1" in 
@@ -29,6 +31,15 @@ while :; do
             IMAGE_TAG='kaggle/rstats-gpu-build'
             DOCKERFILE='gpu.Dockerfile'
             ;;
+        -b|--base-image-tag)
+            if [[ -z $2 ]]; then
+                usage
+                printf 'ERROR: No TAG specified after the %s flag.\n' "$1" >&2
+                exit
+            fi
+            BUILD_ARGS="--build-arg BASE_TAG=$2"
+            shift # skip the flag value
+            ;;
         -?*)
             usage
             printf 'ERROR: Unknown option: %s\n' "$1" >&2
@@ -41,9 +52,12 @@ while :; do
     shift
 done
 
+BUILD_ARGS+=" --build-arg ncpus=$NCPUS"
+
 readonly CACHE_FLAG
 readonly DOCKERFILE
 readonly IMAGE_TAG
+readonly BUILD_ARGS
 
 set -x
-docker build --rm --pull $CACHE_FLAG -t "$IMAGE_TAG" -f "$DOCKERFILE" --build-arg ncpus=$NCPUS .
+docker build --rm --pull $CACHE_FLAG -t "$IMAGE_TAG" -f "$DOCKERFILE" $BUILD_ARGS .

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -1,5 +1,6 @@
+ARG BASE_TAG=staging
 FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04 AS nvidia
-FROM gcr.io/kaggle-images/rstats:staging
+FROM gcr.io/kaggle-images/rstats:${BASE_TAG}
 ARG ncpus=1
 
 ADD clean-layer.sh  /tmp/clean-layer.sh


### PR DESCRIPTION
Equivalent to the `build` script for the Python image:
https://github.com/Kaggle/docker-python/blob/master/build#L12

Next:
- Avoid race condition in parallel build like what was done here for the Python image: https://github.com/Kaggle/docker-python/pull/492

154237926