### PR TITLE
Fix gpu by changing the path set by R

### DIFF
--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -42,6 +42,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
     /tmp/clean-layer.sh
 
+# Hack to fix R trying to use CUDA in `/usr/lib/x86_64-linux-gnu` directory instead
+# of `/usr/local/nvidia/lib64` (b/152401083).
+# For some reason, the CUDA file `libcuda.so.418.67` in the former directory is empty.
+# R's ldpaths modifies LD_LIBRARY_PATH on start by adding `/usr/lib/x86_64-linux-gnu` upfront.
+RUN ls -d /usr/lib/x86_64-linux-gnu/* | egrep '(libcuda|libnvidia)' | xargs rm
+
 ENV CUDA_HOME=/usr/local/cuda
 
 # Install tensorflow with GPU support

--- a/ldpaths
+++ b/ldpaths
@@ -1,0 +1,24 @@
+: ${JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64}
+: ${R_JAVA_LD_LIBRARY_PATH=${JAVA_HOME}/lib/server}
+if test -n "/usr/local/lib"; then
+: ${R_LD_LIBRARY_PATH=${R_HOME}/lib:/usr/local/lib}
+else
+: ${R_LD_LIBRARY_PATH=${R_HOME}/lib}
+fi
+if test -n "${R_JAVA_LD_LIBRARY_PATH}"; then
+  R_LD_LIBRARY_PATH="${R_LD_LIBRARY_PATH}:${R_JAVA_LD_LIBRARY_PATH}"
+fi
+## This is DYLD_FALLBACK_LIBRARY_PATH on Darwin (macOS) and
+## LD_LIBRARY_PATH elsewhere.
+## However, on macOS >=10.11 (if SIP is enabled, the default), the
+## environment value will not be passed to a script such as R.sh, so
+## would not seen here.
+if test -z "${LD_LIBRARY_PATH}"; then
+  LD_LIBRARY_PATH="${R_LD_LIBRARY_PATH}"
+else
+  LD_LIBRARY_PATH="${R_LD_LIBRARY_PATH}:${LD_LIBRARY_PATH}"
+fi
+if test -n "/usr/lib/x86_64-linux-gnu"; then
+: ${LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/lib/x86_64-linux-gnu}
+fi
+export LD_LIBRARY_PATH


### PR DESCRIPTION
This is hopefully a temporary solution.

Original `ldpaths` file content: 
```
: ${JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64}
: ${R_JAVA_LD_LIBRARY_PATH=${JAVA_HOME}/lib/server}
if test -n "/usr/local/lib:/usr/lib/x86_64-linux-gnu"; then
: ${R_LD_LIBRARY_PATH=${R_HOME}/lib:/usr/local/lib:/usr/lib/x86_64-linux-gnu}
else
: ${R_LD_LIBRARY_PATH=${R_HOME}/lib}
fi
if test -n "${R_JAVA_LD_LIBRARY_PATH}"; then
  R_LD_LIBRARY_PATH="${R_LD_LIBRARY_PATH}:${R_JAVA_LD_LIBRARY_PATH}"
fi
## This is DYLD_FALLBACK_LIBRARY_PATH on Darwin (macOS) and
## LD_LIBRARY_PATH elsewhere.
## However, on macOS >=10.11 (if SIP is enabled, the default), the
## environment value will not be passed to a script such as R.sh, so
## would not seen here.
if test -z "${LD_LIBRARY_PATH}"; then
  LD_LIBRARY_PATH="${R_LD_LIBRARY_PATH}"
else
  LD_LIBRARY_PATH="${R_LD_LIBRARY_PATH}:${LD_LIBRARY_PATH}"
fi
export LD_LIBRARY_PATH
```

Instead of setting `/usr/lib/x86_64-linux-gnu` in front of the path, it's moved at the end.