### PR TITLE
pip install papermill

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,8 @@ RUN apt-get install -y libzmq3-dev python-pip default-jdk && \
     mkdir -p /root/.jupyter/kernels && \
     cp -r /root/.local/share/jupyter/kernels/ir /root/.jupyter/kernels && \
     touch /root/.jupyter/jupyter_nbconvert_config.py && touch /root/.jupyter/migrated && \
+    # papermill can replace nbconvert for executing notebooks
+    pip install papermill && \
     /tmp/clean-layer.sh
 
 # Tensorflow and Keras

--- a/tests/test_papermill.R
+++ b/tests/test_papermill.R
@@ -1,0 +1,12 @@
+context("papermill")
+
+test_that("papermill exists", {
+	expect_error({
+		library(jsonlite)
+
+		results <- system("papermill /input/tests/data/notebook.ipynb -",
+			intern = TRUE)
+		json <- fromJSON(results, simplifyVector = FALSE)
+		expect_equal(json$cells[[1]]$outputs[[1]]$text[[1]], "[1] 999\n")
+    }, NA) # expect no error to be thrown
+})


### PR DESCRIPTION
papermill provides a bunch of nice features for executing notebooks, including ones not provided by nbconvert.

Some key features we want:
- dump cell output to logs
- stop on cell error, but still include cell output up to the errored cell