### PR TITLE
Install specific version of LightGBM

### DIFF
--- a/package_installs.R
+++ b/package_installs.R
@@ -4,7 +4,7 @@ options(Ncpus = parallel::detectCores())
 
 # Install the lightGBM installer package
 install_github("Laurae2/lgbdl")
-lgbdl::lgb.dl(compiler = "gcc")
+lgbdl::lgb.dl(compiler = "gcc", commit = "tags/v2.3.1")
 
 install_github("hadley/ggplot2")    # ggthemes is built against the latest ggplot2
 install_github("jrnold/ggthemes")


### PR DESCRIPTION
By default, the version from `master` is installed which is unstable.

BUG=157415837