### PR TITLE
Move JWE for user secrets to Kaggle Authorization header instead of r…

### DIFF
--- a/kaggle/kaggle_bigquery.R
+++ b/kaggle/kaggle_bigquery.R
@@ -10,7 +10,7 @@
 
 KAGGLE_USER_SECRETS_TOKEN <- Sys.getenv("KAGGLE_USER_SECRETS_TOKEN")
 KAGGLE_BASE_URL <- Sys.getenv("KAGGLE_URL_BASE")
-GET_USER_SECRET_ENDPONT = "/requests/GetUserSecretRequest"
+GET_USER_SECRET_ENDPOINT = "/requests/GetUserSecretRequest"
 
 # We create a Token2.0 Credential object (from httr library) and use bigrquery's set_access_cred
 # to override the interactive authentication (https://github.com/r-dbi/bigrquery/blob/master/R/auth.R).
@@ -30,7 +30,7 @@ TokenBigQueryKernel <- R6::R6Class("TokenBigQueryKernel", inherit = Token2.0, li
     request_body <- list(Target = 1)
     auth_header <- paste0("Bearer ", KAGGLE_USER_SECRETS_TOKEN)
     headers <- add_headers(c("X-Kaggle-Authorization" = auth_header))
-    response <- POST(paste0(KAGGLE_BASE_URL, GET_USER_SECRET_ENDPONT),
+    response <- POST(paste0(KAGGLE_BASE_URL, GET_USER_SECRET_ENDPOINT),
                      headers,
                      # Reset the cookies on each request, since the server expects none.
                      handle = handle(''),

--- a/kaggle/kaggle_bigquery.R
+++ b/kaggle/kaggle_bigquery.R
@@ -27,8 +27,15 @@ TokenBigQueryKernel <- R6::R6Class("TokenBigQueryKernel", inherit = Token2.0, li
     if (KAGGLE_USER_SECRETS_TOKEN == '') {
       stop("Expected KAGGLE_USER_SECRETS_TOKEN environment variable to be present.", call. = FALSE)
     }
-    request_body <- list(JWE = KAGGLE_USER_SECRETS_TOKEN, Target = 1)
-    response <- POST(paste0(KAGGLE_BASE_URL, GET_USER_SECRET_ENDPONT), body = request_body, encode = "json")
+    request_body <- list(Target = 1)
+    auth_header <- paste0("Bearer ", KAGGLE_USER_SECRETS_TOKEN)
+    headers <- add_headers(c("X-Kaggle-Authorization" = auth_header))
+    response <- POST(paste0(KAGGLE_BASE_URL, GET_USER_SECRET_ENDPONT),
+                     headers,
+                     # Reset the cookies on each request, since the server expects none.
+                     handle = handle(''),
+                     body = request_body,
+                     encode = "json")
     if (http_error(response) || !identical(content(response)$wasSuccessful, TRUE)) {
       err <- paste("Unable to refresh token. Please ensure you have a connected BigQuery account. Error: ",
                         paste(content(response, "text", encoding = 'utf-8')))

--- a/kaggle/kaggle_secrets.R
+++ b/kaggle/kaggle_secrets.R
@@ -13,8 +13,17 @@ get_user_secret <- function(label) {
     if (KAGGLE_USER_SECRETS_TOKEN == '') {
       stop("Expected KAGGLE_USER_SECRETS_TOKEN environment variable to be present.", call. = FALSE)
     }
-    request_body <- list(JWE = KAGGLE_USER_SECRETS_TOKEN, Label = label)
-    response <- POST(paste0(KAGGLE_BASE_URL, GET_USER_SECRET_BY_LABEL_ENDPONT), body = request_body, encode = "json")
+    request_body <- list(Label = label)
+    auth_header <- paste0("Bearer ", KAGGLE_USER_SECRETS_TOKEN)
+    headers <- add_headers(c("X-Kaggle-Authorization" = auth_header))
+    response <- POST(
+      paste0(KAGGLE_BASE_URL,GET_USER_SECRET_BY_LABEL_ENDPONT),
+      headers,
+      # Reset the cookies on each request, since the server expects none.
+      handle = handle(''),
+      body = request_body,
+      encode = "json"
+    )
     if (http_error(response) || !identical(content(response)$wasSuccessful, TRUE)) {
       err <- paste("Unable to get user secret. Please ensure you have internet enabled. Error: ",
                         paste(content(response, "text", encoding = 'utf-8')))

--- a/kaggle/kaggle_secrets.R
+++ b/kaggle/kaggle_secrets.R
@@ -8,7 +8,7 @@
 get_user_secret <- function(label) {
     KAGGLE_USER_SECRETS_TOKEN <- Sys.getenv("KAGGLE_USER_SECRETS_TOKEN")
     KAGGLE_BASE_URL <- Sys.getenv("KAGGLE_URL_BASE")
-    GET_USER_SECRET_BY_LABEL_ENDPONT = "/requests/GetUserSecretByLabelRequest"
+    GET_USER_SECRET_BY_LABEL_ENDPOINT = "/requests/GetUserSecretByLabelRequest"
 
     if (KAGGLE_USER_SECRETS_TOKEN == '') {
       stop("Expected KAGGLE_USER_SECRETS_TOKEN environment variable to be present.", call. = FALSE)
@@ -17,7 +17,7 @@ get_user_secret <- function(label) {
     auth_header <- paste0("Bearer ", KAGGLE_USER_SECRETS_TOKEN)
     headers <- add_headers(c("X-Kaggle-Authorization" = auth_header))
     response <- POST(
-      paste0(KAGGLE_BASE_URL,GET_USER_SECRET_BY_LABEL_ENDPONT),
+      paste0(KAGGLE_BASE_URL, GET_USER_SECRET_BY_LABEL_ENDPOINT),
       headers,
       # Reset the cookies on each request, since the server expects none.
       handle = handle(''),

--- a/tests/test_secrets.R
+++ b/tests/test_secrets.R
@@ -1,0 +1,5 @@
+context("user_secrets")
+
+test_that("get_user_secret exists", {
+    exists('get_user_secret')
+})


### PR DESCRIPTION
…equest body.