### PR TITLE
Remove gpuR and kmcudaR

### DIFF
--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -69,6 +69,4 @@ RUN CPATH=/usr/local/cuda/targets/x86_64-linux/include install2.r --error --ncpu
     h2o4gpu \
     kmcudaR
 
-RUN R -e 'install.packages("gpuR", INSTALL_opts=c("--no-test-load"))'
-
 CMD ["R"]

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -66,7 +66,6 @@ RUN apt-get install -y --no-install-recommends ocl-icd-opencl-dev && \
 
 # Install GPU specific packages
 RUN CPATH=/usr/local/cuda/targets/x86_64-linux/include install2.r --error --ncpus $ncpus --repo http://cran.rstudio.com \
-    h2o4gpu \
-    kmcudaR
+    h2o4gpu
 
 CMD ["R"]


### PR DESCRIPTION
They both fail to install and haven't been used by Kagglers for at least 2 months.