### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,12 @@ RUN apt-get update && \
     patch && \
     /tmp/clean-layer.sh
 
+RUN apt-get update && \
+    apt-get install -y libsox3 flac libflac8 && \
+    apt-get install -y ffmpeg x264 x265 libavfilter-dev libx264-dev libx265-dev && \
+    patch && \
+    /tmp/clean-layer.sh
+
 RUN apt-get update && apt-get install -y libatlas-base-dev libopenblas-dev libopencv-dev && \
     cd /usr/local/src && git clone --recursive --depth=1 --branch v1.6.x https://github.com/apache/incubator-mxnet.git mxnet && \
     cd mxnet && make -j $(nproc) USE_OPENCV=1 USE_BLAS=openblas && make rpkg && \

--- a/package_installs.R
+++ b/package_installs.R
@@ -40,3 +40,4 @@ install_github("thomasp85/patchwork")
 install.packages("topicmodels")
 
 install.packages("tesseract")
+install.packages("av")


### PR DESCRIPTION
flac completes functionality of seewave, which does not require compilation to install, but will not be able to perform basic conversion from standard audio archive fmt .flac to wave in `wav2flac`, and most subsidiary seewave functions expect .wav as input. 

libsox3 enhances calls to seewave::sox w.r.t. filters

ffmpeg and attendant libs provide basis to install `av`, another comprehensive approach to audio/video processing