### PR TITLE
add timereg package

### DIFF
--- a/package_installs.R
+++ b/package_installs.R
@@ -48,3 +48,6 @@ install_torch(reinstall = TRUE)
 
 # The R Keras package must be reinstalled after installing it in the python virtualenv.
 install.packages("keras")
+
+# install timereg mainly for the qcut() function which bins observations by quantile - see https://cran.r-project.org/web/packages/timereg/timereg.pdf
+install.packages("timereg")


### PR DESCRIPTION
So i can build R Notebook in Kaggle which replicates the gist i recently published, looking to conduct various EDA and replicate some logistic regression and torch neural network analyses in a Kaggle Notebook - see https://gist.github.com/jaymon0703/0b29f6aa1fa7990a8fcd796f735ef7fd