### PR TITLE
Use a unique name for the build date argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,5 +86,8 @@ LABEL build-date=$BUILD_DATE
 
 # Find the current release git hash & build date inside the kernel editor.
 RUN echo "$GIT_COMMIT" > /etc/git_commit && echo "$BUILD_DATE" > /etc/build_date
+RUN echo "Hello Philmod"
+RUN echo "$BUILD_DATE"
+RUN cat /etc/build_date
 
 CMD ["R"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,15 +79,12 @@ RUN Rscript --vanilla /tmp/bioconductor_installs.R
 RUN Rscript --vanilla /tmp/install_iR.R
 
 ARG GIT_COMMIT=unknown
-ARG BUILD_DATE=unknown
+ARG BUILD_DATE_RSTATS=unknown
 
 LABEL git-commit=$GIT_COMMIT
-LABEL build-date=$BUILD_DATE
+LABEL build-date=$BUILD_DATE_RSTATS
 
 # Find the current release git hash & build date inside the kernel editor.
-RUN echo "$GIT_COMMIT" > /etc/git_commit && echo "$BUILD_DATE" > /etc/build_date
-RUN echo "Hello Philmod"
-RUN echo "$BUILD_DATE"
-RUN cat /etc/build_date
+RUN echo "$GIT_COMMIT" > /etc/git_commit && echo "$BUILD_DATE_RSTATS" > /etc/build_date
 
 CMD ["R"]

--- a/build
+++ b/build
@@ -54,7 +54,7 @@ done
 
 BUILD_ARGS+=" --build-arg ncpus=$NCPUS"
 BUILD_ARGS+=" --build-arg GIT_COMMIT=$(git rev-parse HEAD)"
-BUILD_ARGS+=" --build-arg BUILD_DATE=$(date '+%Y%m%d-%H%M%S')"
+BUILD_ARGS+=" --build-arg BUILD_DATE_RSTATS=$(date '+%Y%m%d-%H%M%S')"
 
 readonly CACHE_FLAG
 readonly DOCKERFILE


### PR DESCRIPTION
To avoid conflict with an homonymous environment variable coming from the `rcran` image.

```
❯ docker run -it gcr.io/kaggle-images/rstats:build-date-bug-staging /bin/bash
root@fabf64a0b878:/# cat /etc/build_date
20210318-132538
```

http://b/183049196