### PR TITLE
Update package_installs.R

### DIFF
--- a/package_installs.R
+++ b/package_installs.R
@@ -52,5 +52,6 @@ install.packages("keras")
 # In order to run tifffile with dependence imagecodecs, these two python packages have to be installed to 
 # work with reticulate import. Using import_from_path, after downloading those wheels (.whl) dont work,
 # since imagecodecs is a dependence 
+library(reticulate)
 py_install("imagecodecs")
 py_install("tifffile")

--- a/package_installs.R
+++ b/package_installs.R
@@ -48,3 +48,9 @@ install_torch(reinstall = TRUE)
 
 # The R Keras package must be reinstalled after installing it in the python virtualenv.
 install.packages("keras")
+
+# In order to run tifffile with dependence imagecodecs, these two python packages have to be installed to 
+# work with reticulate import. Using import_from_path, after downloading those wheels (.whl) dont work,
+# since imagecodecs is a dependence 
+py_install("imagecodecs")
+py_install("tifffile")


### PR DESCRIPTION
imagecodecs need to be installed in order to use tifffile in the HuBMAP kaggle competition.

I think, that is the reason my notebooks are getting successives errors, since im trying to install it with virtualenv_install.