### PR TITLE
Fix nbconvert template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,7 @@ ADD install_iR.R  /tmp/install_iR.R
 ADD bioconductor_installs.R /tmp/bioconductor_installs.R
 ADD package_installs.R /tmp/package_installs.R
 ADD nbconvert-extensions.tpl /opt/kaggle/nbconvert-extensions.tpl
+ADD kaggle/template_conf.json /opt/kaggle/conf.json
 # Install with `--vanilla` flag to avoid conflict. https://support.bioconductor.org/p/57187/
 RUN Rscript --vanilla /tmp/package_installs.R
 RUN Rscript --vanilla /tmp/bioconductor_installs.R

--- a/kaggle/template_conf.json
+++ b/kaggle/template_conf.json
@@ -1,0 +1,13 @@
+{
+    "base_template": "classic",
+    "mimetypes": {
+        "text/html": true
+    },
+    "preprocessors": {
+        "100-pygments": {
+            "type": "nbconvert.preprocessors.CSSHTMLHeaderPreprocessor",
+            "enabled": true,
+            "style": "default"
+        }
+    }
+}

--- a/nbconvert-extensions.tpl
+++ b/nbconvert-extensions.tpl
@@ -4,7 +4,7 @@ All cell metadata starting with '_kg_' will be included with its value ({key}-{v
 as a class in the cell's DIV container
 #}
     
-{% extends 'full.tpl'%}
+{% extends 'classic/index.html.j2'%}
 {% block any_cell %}
     <div class="{% for k in cell['metadata'] if k.startswith("_kg_") %}{{k}}-{{cell['metadata'][k] | lower}} {% endfor %}">
         {{ super() }}

--- a/tests/test_nbconvert.R
+++ b/tests/test_nbconvert.R
@@ -13,8 +13,8 @@ test_that("nbconvert to notebook", {
 
 test_that("nbconvert to html", {
 	expect_error({
-		results <- system("jupyter nbconvert --to html --output \"__results__.html\" --template /opt/kaggle/nbconvert-extensions.tpl --Exporter.preprocessors=[\\\"nbconvert.preprocessors.ExtractOutputPreprocessor\\\"] \"/input/tests/data/notebook.ipynb\"",
+		results <- system("jupyter nbconvert --to html --stdout --template /opt/kaggle/nbconvert-extensions.tpl --Exporter.preprocessors=[\\\"nbconvert.preprocessors.ExtractOutputPreprocessor\\\"] \"/input/tests/data/notebook.ipynb\"",
 			intern = TRUE)
-		expect_match(results, "Hello World")
+		expect_match(toString(results), ".*>999<.*")  # [...] <span class="n">x</span> <span class="o">&lt;-</span> <span class="m">999</span> [...]
     }, NA) # expect no error to be thrown
 })

--- a/tests/test_nbconvert.R
+++ b/tests/test_nbconvert.R
@@ -1,6 +1,6 @@
 context("nbconvert")
 
-test_that("nbconvert exists", {
+test_that("nbconvert to notebook", {
 	expect_error({
 		library(jsonlite)
 
@@ -8,5 +8,13 @@ test_that("nbconvert exists", {
 			intern = TRUE)
 		json <- fromJSON(results, simplifyVector = FALSE)
 		expect_equal(json$cells[[1]]$outputs[[1]]$text[[1]], "[1] 999\n")
+    }, NA) # expect no error to be thrown
+})
+
+test_that("nbconvert to html", {
+	expect_error({
+		results <- system("jupyter nbconvert --to html --output \"__results__.html\" --template /opt/kaggle/nbconvert-extensions.tpl --Exporter.preprocessors=[\\\"nbconvert.preprocessors.ExtractOutputPreprocessor\\\"] \"/input/tests/data/notebook.ipynb\"",
+			intern = TRUE)
+		expect_match(results, "Hello World")
     }, NA) # expect no error to be thrown
 })


### PR DESCRIPTION
Use the non-deprecated nbconvert template and add template configuration file.

The config is a breaking change in nbconvert 6.x

Also added a unit test to cover this kind of breakage, before we create new SDGs.

http://b/170301227