### PR TITLE
Upgrade to R 4.0.5 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && \
     /tmp/clean-layer.sh
 
 RUN apt-get update && apt-get install -y build-essential git ninja-build ccache  libatlas-base-dev libopenblas-dev libopencv-dev python3-opencv && \
-    cd /usr/local/opt && git clone --recursive --depth=1 --branch v1.8.x https://github.com/apache/incubator-mxnet.git mxnet && \
+    cd /usr/local/share && git clone --recursive --depth=1 --branch v1.8.x https://github.com/apache/incubator-mxnet.git mxnet && \
     cd mxnet && cp config/linux.cmake config.cmake && rm -rf build && \
     mkdir -p build && cd build && cmake .. && cmake --build . --parallel $(nproc) && \
     cd .. && make -f R-package/Makefile rpkg && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_TAG=latest
+ARG BASE_TAG=r4
 
 FROM gcr.io/kaggle-images/rcran:${BASE_TAG}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     patch libgit2-dev && \
     /tmp/clean-layer.sh
 
-RUN apt-get update && apt-get install -y libatlas-base-dev libopenblas-dev libopencv-dev && \
+RUN apt-get update && apt-get install -y libatlas-base-dev libopenblas-dev libopencv-dev python3-opencv && \
     cd /usr/local/src && git clone --recursive --depth=1 --branch v1.6.x https://github.com/apache/incubator-mxnet.git mxnet && \
     cd mxnet && make -j$(nproc) USE_OPENCV=1 USE_BLAS=openblas && make rpkg && \
     /tmp/clean-layer.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get install -y libhdf5-dev && \
     apt-get install -y libpoppler-cpp-dev libtesseract-dev tesseract-ocr-eng && \
     /tmp/clean-layer.sh
 
-RUN apt-get install -y libzmq3-dev python-pip default-jdk && \
+RUN apt-get install -y libzmq3-dev default-jdk && \
     apt-get install -y python-dev libcurl4-openssl-dev libssl-dev && \
     pip install jupyter pycurl && \
     # Install older tornado - https://github.com/jupyter/notebook/issues/4437

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ADD clean-layer.sh  /tmp/clean-layer.sh
 
 # Default to python3.7
 RUN apt-get update && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1 && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 && \
     update-alternatives --config python && \
     apt install -y python3-pip python3-venv && \
     /tmp/clean-layer.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,9 @@ RUN apt-get update && \
     /tmp/clean-layer.sh
 
 RUN apt-get update && apt-get install -y build-essential git ninja-build ccache  libatlas-base-dev libopenblas-dev libopencv-dev python3-opencv && \
-    cd /usr/local/src && git clone --recursive --depth=1 --branch v1.8.x https://github.com/apache/incubator-mxnet.git mxnet && \
-    cd mxnet && cp config/linux.cmake config.cmake && rm -rf build && mkdir -p build && cd build && cmake .. && cmake --build . --parallel $(nproc) && \
+    cd /usr/local/opt && git clone --recursive --depth=1 --branch v1.8.x https://github.com/apache/incubator-mxnet.git mxnet && \
+    cd mxnet && cp config/linux.cmake config.cmake && rm -rf build && \
+    mkdir -p build && cd build && cmake .. && cmake --build . --parallel $(nproc) && \
     cd .. && make -f R-package/Makefile rpkg && \
     /tmp/clean-layer.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,9 @@ RUN apt-get update && \
     patch libgit2-dev && \
     /tmp/clean-layer.sh
 
-RUN apt-get update && apt-get install -y libatlas-base-dev libopenblas-dev libopencv-dev python3-opencv && \
-    cd /usr/local/src && git clone --recursive --depth=1 --branch v1.6.x https://github.com/apache/incubator-mxnet.git mxnet && \
-    cd mxnet && make -j$(nproc) USE_OPENCV=1 USE_BLAS=openblas && make rpkg && \
+RUN apt-get update && apt-get install -y build-essential git ninja-build ccache  libatlas-base-dev libopenblas-dev libopencv-dev python3-opencv && \
+    cd /usr/local/src && git clone --recursive --depth=1 --branch v1.8.x https://github.com/apache/incubator-mxnet.git mxnet && \
+    cd mxnet && cp config/linux.cmake config.cmake && rm -rf build && mkdir -p build && cd build && cmake .. && cmake --build . --parallel $(nproc) && make -f R-package/Makefile rpkg && \
     /tmp/clean-layer.sh
 
     # Needed for "h5" library

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_TAG=r4
+ARG BASE_TAG=latest
 
 FROM gcr.io/kaggle-images/rcran:${BASE_TAG}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,8 +64,7 @@ RUN curl -sL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.
     /tmp/clean-layer.sh
 
 # Tensorflow and Keras
-RUN conda activate r-reticulate && \
-    R -e 'keras::install_keras(tensorflow = "2.3", extra_packages = c("pandas", "numpy", "pycryptodome"), method="conda")'
+RUN R -e 'keras::install_keras(tensorflow = "2.3", extra_packages = c("pandas", "numpy", "pycryptodome"), method="conda")'
 
 # Install kaggle libraries.
 # Do this at the end to avoid rebuilding everything when any change is made.

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,11 +57,15 @@ RUN apt-get install -y libzmq3-dev default-jdk && \
     pip install papermill && \
     /tmp/clean-layer.sh
 
+# Miniconda
+RUN curl -sL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o mconda-install.sh && \
+    bash -x mconda-install.sh -b -p miniconda && \
+    rm mconda-install.sh && \
+    /tmp/clean-layer.sh
+
 # Tensorflow and Keras
-# Keras sets up a virtualenv and installs tensorflow
-# in the WORKON_HOME directory, so choose an explicit location for it.
-ENV WORKON_HOME=/usr/local/share/.virtualenvs
-RUN pip install --user virtualenv && R -e 'keras::install_keras(tensorflow = "2.3", extra_packages = c("pandas", "numpy", "pycryptodome"))'
+RUN conda activate r-reticulate && \
+    R -e 'keras::install_keras(tensorflow = "2.3", extra_packages = c("pandas", "numpy", "pycryptodome"), method="conda")'
 
 # Install kaggle libraries.
 # Do this at the end to avoid rebuilding everything when any change is made.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN apt-get update && \
 
 RUN apt-get update && apt-get install -y build-essential git ninja-build ccache  libatlas-base-dev libopenblas-dev libopencv-dev python3-opencv && \
     cd /usr/local/src && git clone --recursive --depth=1 --branch v1.8.x https://github.com/apache/incubator-mxnet.git mxnet && \
-    cd mxnet && cp config/linux.cmake config.cmake && rm -rf build && mkdir -p build && cd build && cmake .. && cmake --build . --parallel $(nproc) && make -f R-package/Makefile rpkg && \
+    cd mxnet && cp config/linux.cmake config.cmake && rm -rf build && mkdir -p build && cd build && cmake .. && cmake --build . --parallel $(nproc) && \
+    cd .. && make -f R-package/Makefile rpkg && \
     /tmp/clean-layer.sh
 
     # Needed for "h5" library

--- a/package_installs.R
+++ b/package_installs.R
@@ -46,6 +46,10 @@ install.packages("topicmodels")
 
 install.packages("tesseract")
 
+# Try to reinstall igraph and imager her until fixed in rcran.
+install.packages("igraph")
+install.packages("imager")
+
 # Torch: install the full package upfront otherwise it will be installed on loading the package which doesn't work for kernels
 # without internet (competitions for example).
 library(torch)


### PR DESCRIPTION
Changes: 
- Use rcran with R 4.0.5
- Upgrade mxnet to 1.8
- Use miniconda to install keras and tensorflow
- Make sure to install `imager` which wasn't properly installed on rcran

http://b/179893188