### PR TITLE
Fix papermill

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,12 @@ RUN curl -sL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.
     /tmp/clean-layer.sh
 ENV PATH=/miniconda/bin:${PATH}
 
+# R configuration.
+# Including the path for conda.
+ADD kaggle/ /kaggle/
+ENV R_HOME=/usr/local/lib/R
+ADD RProfile.R /usr/local/lib/R/etc/Rprofile.site
+
 RUN apt-get update && \
     apt-get install apt-transport-https && \
     apt-get install -y -f r-cran-rgtk2 && \
@@ -72,10 +78,6 @@ RUN apt-get install -y libzmq3-dev default-jdk && \
 RUN R -e 'keras::install_keras(tensorflow = "2.3", extra_packages = c("pandas", "numpy", "pycryptodome"), method="conda")'
 
 # Install kaggle libraries.
-# Do this at the end to avoid rebuilding everything when any change is made.
-ADD kaggle/ /kaggle/
-# RProfile sources files from /kaggle/ so ensure this runs after ADDing it.
-ENV R_HOME=/usr/local/lib/R
 ADD RProfile.R /usr/local/lib/R/etc/Rprofile.site
 ADD install_iR.R  /tmp/install_iR.R
 ADD bioconductor_installs.R /tmp/bioconductor_installs.R

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,13 @@ RUN apt-get update && \
 RUN apt purge -y python2.7-minimal
 RUN ln -sf /usr/bin/python3.8 /usr/bin/python
 
+# Miniconda
+RUN curl -sL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o mconda-install.sh && \
+    bash -x mconda-install.sh -b -p miniconda && \
+    rm mconda-install.sh && \
+    /tmp/clean-layer.sh
+ENV PATH=/miniconda/bin:${PATH}
+
 RUN apt-get update && \
     apt-get install apt-transport-https && \
     apt-get install -y -f r-cran-rgtk2 && \
@@ -37,13 +44,6 @@ RUN apt-get install -y libhdf5-dev && \
     # Needed for "tesseract" library
     apt-get install -y libpoppler-cpp-dev libtesseract-dev tesseract-ocr-eng && \
     /tmp/clean-layer.sh
-
-# Miniconda
-RUN curl -sL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o mconda-install.sh && \
-    bash -x mconda-install.sh -b -p miniconda && \
-    rm mconda-install.sh && \
-    /tmp/clean-layer.sh
-ENV PATH=/miniconda/bin:${PATH}
 
 RUN apt-get install -y libzmq3-dev default-jdk && \
     apt-get install -y python-dev libcurl4-openssl-dev libssl-dev && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
     apt install -y python3-pip python3-venv && \
     /tmp/clean-layer.sh
 
+RUN apt purge -y python2.7-minimal
 RUN ln -sf /usr/bin/python3.8 /usr/bin/python
 
 RUN apt-get update && \
@@ -65,6 +66,7 @@ RUN curl -sL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.
     bash -x mconda-install.sh -b -p miniconda && \
     rm mconda-install.sh && \
     /tmp/clean-layer.sh
+ENV PATH=/miniconda/bin:${PATH}
 
 # Tensorflow and Keras
 RUN R -e 'keras::install_keras(tensorflow = "2.3", extra_packages = c("pandas", "numpy", "pycryptodome"), method="conda")'

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,13 @@ FROM gcr.io/kaggle-images/rcran:${BASE_TAG}
 
 ADD clean-layer.sh  /tmp/clean-layer.sh
 
-# Default to python3.7
+# Default to python3.8
 RUN apt-get update && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 && \
     update-alternatives --config python && \
     apt install -y python3-pip python3-venv && \
     /tmp/clean-layer.sh
+RUN ln -sf /usr/bin/python3.8 /usr/bin/python
 
 RUN apt-get update && \
     apt-get install apt-transport-https && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get update && \
     apt install -y python3-pip python3-venv && \
     /tmp/clean-layer.sh
 
+RUN ln -sf /usr/bin/python3.8 /usr/bin/python
+
 RUN apt-get update && \
     apt-get install apt-transport-https && \
     apt-get install -y -f r-cran-rgtk2 && \
@@ -82,8 +84,6 @@ ADD kaggle/template_conf.json /opt/kaggle/conf.json
 RUN Rscript --vanilla /tmp/package_installs.R
 RUN Rscript --vanilla /tmp/bioconductor_installs.R
 RUN Rscript --vanilla /tmp/install_iR.R
-
-RUN ln -sf /usr/bin/python3.8 /usr/bin/python
 
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE_RSTATS=unknown

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,15 +53,16 @@ RUN apt-get install -y libhdf5-dev && \
 
 RUN apt-get install -y libzmq3-dev default-jdk && \
     apt-get install -y python-dev libcurl4-openssl-dev libssl-dev && \
-    conda install -c conda-forge -y pip notebook nb_conda_kernels && \
-    pip install jupyter pycurl && \
+    conda install -c conda-forge -y pip r_env r-irkernel \
+      notebook=5.5.0 nb_conda_kernels nbconvert && \
+    conda install -c conda-forge jupyter pycurl && \
     # Install older tornado - https://github.com/jupyter/notebook/issues/4437
-    pip install "tornado<6" && \
+    conda install -c conda-forge "tornado<6" && \
     # to avoid breaking UI change, pin the jupyter notebook package
     # the latest version also has a regression on the NotebookApp.ip option
     # see: https://www.google.com/url?q=https://github.com/jupyter/notebook/issues/3946&sa=D&usg=AFQjCNFieP7srXVWqX8PDetXGfhyxRmO4Q
-    pip install notebook==5.5.0 && \
-    pip install nbconvert && \
+    # pip install notebook==5.5.0 && \
+    # pip install nbconvert && \
     R -e 'IRkernel::installspec()' && \
     # Build pyzmq from source instead of using a pre-built binary.
     yes | pip uninstall pyzmq && \
@@ -72,7 +73,7 @@ RUN apt-get install -y libzmq3-dev default-jdk && \
     cp -r /root/.local/share/jupyter/kernels/ir /root/.jupyter/kernels && \
     touch /root/.jupyter/jupyter_nbconvert_config.py && touch /root/.jupyter/migrated && \
     # papermill can replace nbconvert for executing notebooks
-    pip install papermill && \
+    conda install -c conda-forge papermill && \
     /tmp/clean-layer.sh
 
 # Tensorflow and Keras

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update && \
     update-alternatives --config python && \
     apt install -y python3-pip python3-venv && \
     /tmp/clean-layer.sh
-RUN ln -sf /usr/bin/python3.8 /usr/bin/python
 
 RUN apt-get update && \
     apt-get install apt-transport-https && \
@@ -83,6 +82,8 @@ ADD kaggle/template_conf.json /opt/kaggle/conf.json
 RUN Rscript --vanilla /tmp/package_installs.R
 RUN Rscript --vanilla /tmp/bioconductor_installs.R
 RUN Rscript --vanilla /tmp/install_iR.R
+
+RUN ln -sf /usr/bin/python3.8 /usr/bin/python
 
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE_RSTATS=unknown

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,13 @@ RUN apt-get install -y libhdf5-dev && \
     apt-get install -y libpoppler-cpp-dev libtesseract-dev tesseract-ocr-eng && \
     /tmp/clean-layer.sh
 
+# Miniconda
+RUN curl -sL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o mconda-install.sh && \
+    bash -x mconda-install.sh -b -p miniconda && \
+    rm mconda-install.sh && \
+    /tmp/clean-layer.sh
+ENV PATH=/miniconda/bin:${PATH}
+
 RUN apt-get install -y libzmq3-dev default-jdk && \
     apt-get install -y python-dev libcurl4-openssl-dev libssl-dev && \
     pip install jupyter pycurl && \
@@ -60,13 +67,6 @@ RUN apt-get install -y libzmq3-dev default-jdk && \
     # papermill can replace nbconvert for executing notebooks
     pip install papermill && \
     /tmp/clean-layer.sh
-
-# Miniconda
-RUN curl -sL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o mconda-install.sh && \
-    bash -x mconda-install.sh -b -p miniconda && \
-    rm mconda-install.sh && \
-    /tmp/clean-layer.sh
-ENV PATH=/miniconda/bin:${PATH}
 
 # Tensorflow and Keras
 RUN R -e 'keras::install_keras(tensorflow = "2.3", extra_packages = c("pandas", "numpy", "pycryptodome"), method="conda")'

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,15 @@ FROM gcr.io/kaggle-images/rcran:${BASE_TAG}
 
 ADD clean-layer.sh  /tmp/clean-layer.sh
 
-# Default to python3.8
+# Default to python3.7
 RUN apt-get update && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1 && \
     update-alternatives --config python && \
     apt install -y python3-pip python3-venv && \
     /tmp/clean-layer.sh
 
 RUN apt purge -y python2.7-minimal
-RUN ln -sf /usr/bin/python3.8 /usr/bin/python
+RUN ln -sf /usr/bin/python3.7 /usr/bin/python
 
 # Miniconda
 RUN curl -sL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o mconda-install.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get install -y libhdf5-dev && \
 
 RUN apt-get install -y libzmq3-dev default-jdk && \
     apt-get install -y python-dev libcurl4-openssl-dev libssl-dev && \
-    conda install -c conda-forge -y pip r_env r-irkernel \
+    conda install -c conda-forge -y pip r-irkernel \
       notebook=5.5.0 nb_conda_kernels nbconvert && \
     conda install -c conda-forge jupyter pycurl && \
     # Install older tornado - https://github.com/jupyter/notebook/issues/4437

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN apt-get install -y libhdf5-dev && \
 
 RUN apt-get install -y libzmq3-dev default-jdk && \
     apt-get install -y python-dev libcurl4-openssl-dev libssl-dev && \
+    conda install -c conda-forge -y pip notebook nb_conda_kernels && \
     pip install jupyter pycurl && \
     # Install older tornado - https://github.com/jupyter/notebook/issues/4437
     pip install "tornado<6" && \
@@ -65,7 +66,7 @@ RUN apt-get install -y libzmq3-dev default-jdk && \
     # Build pyzmq from source instead of using a pre-built binary.
     yes | pip uninstall pyzmq && \
     pip install pyzmq --no-binary pyzmq && \
-    cp -r /root/.local/share/jupyter/kernels/ir /usr/local/share/jupyter/kernels && \
+    # cp -r /root/.local/share/jupyter/kernels/ir /usr/local/share/jupyter/kernels && \
     # Make sure Jupyter won't try to "migrate" its junk in a read-only container
     mkdir -p /root/.jupyter/kernels && \
     cp -r /root/.local/share/jupyter/kernels/ir /root/.jupyter/kernels && \

--- a/RProfile.R
+++ b/RProfile.R
@@ -1,5 +1,8 @@
 options(repos = list(CRAN = "http://cran.rstudio.com/"))
 
+old_path <- Sys.getenv("PATH")
+Sys.setenv(PATH = paste(old_path, "/miniconda/bin", sep = ":"))
+
 options(device = function() png(width = 900))
 
 # Suppressing package startup messages in package loads

--- a/tests/test_papermill.R
+++ b/tests/test_papermill.R
@@ -10,3 +10,13 @@ test_that("papermill exists", {
 		expect_equal(json$cells[[1]]$outputs[[1]]$text[[1]], "[1] 999\n")
     }, NA) # expect no error to be thrown
 })
+
+test_that("python papermill exists", {
+	expect_error({
+		library(jsonlite)
+
+		results <- system("python -c 'import sys;import papermill as pm; print(pm.__version__)'",
+			intern = TRUE)
+		print(results)
+    }, NA) # expect no error to be thrown
+})

--- a/tests/test_papermill.R
+++ b/tests/test_papermill.R
@@ -13,10 +13,8 @@ test_that("papermill exists", {
 
 test_that("python papermill exists", {
 	expect_error({
-		library(jsonlite)
-
-		results <- system("python -c 'import sys;import papermill as pm; print(pm.__version__)'",
+		res <- system("python -c 'import sys;import papermill as pm; print(pm.__version__)'",
 			intern = TRUE)
-		print(results)
-    }, NA) # expect no error to be thrown
+		expect_match(res, "\\d\\.\\d\\.\\d")
+    }, NA)
 })

--- a/tests/test_papermill.R
+++ b/tests/test_papermill.R
@@ -13,6 +13,7 @@ test_that("papermill exists", {
 
 test_that("python papermill exists", {
 	expect_error({
+		system("python --version")
 		res <- system("python -c 'import sys;import papermill as pm; print(pm.__version__)'",
 			intern = TRUE)
 		expect_match(res, "\\d\\.\\d\\.\\d")


### PR DESCRIPTION
The default python version was not the one on which everything was installed.

Added a unit test that fails with `gcr.io/kaggle-images/rstats:v37`:
```
── Warning (test_papermill.R:15:2): python papermill exists ─────────────────────
running command 'python -c 'import sys;import papermill as pm; print(pm.__version__)'' had status 1
Backtrace:
 1. testthat::expect_error(...) test_papermill.R:15:8
 6. base::system(...) test_papermill.R:16:16

── Failure (test_papermill.R:15:2): python papermill exists ───────────────────────────
`{ ... }` threw an error.
Message: `res` is empty.
Class:   expectation_failure/expectation/error/condition
Backtrace:
 1. testthat::expect_error(...) test_papermill.R:15:8
 6. testthat::expect_match(res, "\\d\\.\\d\\.\\d") test_papermill.R:18:16

[ FAIL 1 | WARN 1 | SKIP 0 | PASS 2 ]
```

but succeeds with this change: 
```
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 4 ] Done!
```

http://b/191304257