### PR TITLE
Include NNS package at R notebook

### DIFF
--- a/package_installs.R
+++ b/package_installs.R
@@ -57,3 +57,6 @@ install_torch(reinstall = TRUE)
 
 # The R Keras package must be reinstalled after installing it in the python virtualenv.
 install_version("keras", version = "2.3.0.0", ask=FALSE)
+
+# NNS - Nonlinear Nonparametric Statistics and models - https://github.com/cran/NNS
+install.packages("NNS")


### PR DESCRIPTION
Hello folks

Could be possible include NNS package? (some non parametric models and statistics)

Some competitions require time to execute notebook (optiver), and install offline takes more than 20 minutes.

This lib is already a CRAN library

Thanks