### PR TITLE
Revert "Upgrade to tensorflow 2.6"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,10 +57,8 @@ RUN apt-get install -y libzmq3-dev default-jdk && \
     /tmp/clean-layer.sh
 
 # Miniconda
-RUN curl -sL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o mconda-install.sh && \
-    bash -x mconda-install.sh -b -p miniconda && \
-    rm mconda-install.sh && \
-    /tmp/clean-layer.sh
+RUN R -e 'reticulate::install_miniconda()'
+ENV RETICULATE_PYTHON=/root/.local/share/r-miniconda/envs/r-reticulate/bin/python
 
 # Tensorflow and Keras
 RUN R -e 'keras::install_keras(tensorflow = "2.3", extra_packages = c("pandas", "numpy", "pycryptodome"), method="conda")'

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,11 +57,13 @@ RUN apt-get install -y libzmq3-dev default-jdk && \
     /tmp/clean-layer.sh
 
 # Miniconda
-RUN R -e 'reticulate::install_miniconda()'
-ENV RETICULATE_PYTHON=/root/.local/share/r-miniconda/envs/r-reticulate/bin/python
+RUN curl -sL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o mconda-install.sh && \
+    bash -x mconda-install.sh -b -p miniconda && \
+    rm mconda-install.sh && \
+    /tmp/clean-layer.sh
 
 # Tensorflow and Keras
-RUN R -e 'keras::install_keras(tensorflow = "2.6", extra_packages = c("pandas", "numpy", "pycryptodome"), method="conda")'
+RUN R -e 'keras::install_keras(tensorflow = "2.3", extra_packages = c("pandas", "numpy", "pycryptodome"), method="conda")'
 
 # Install kaggle libraries.
 # Do this at the end to avoid rebuilding everything when any change is made.

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_TAG=staging
-FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04 AS nvidia
+FROM nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04 AS nvidia
 FROM gcr.io/kaggle-images/rstats:${BASE_TAG}
 ARG ncpus=1
 
@@ -11,12 +11,12 @@ COPY --from=nvidia /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.
 COPY --from=nvidia /etc/apt/trusted.gpg /etc/apt/trusted.gpg.d/cuda.gpg
 
 ENV CUDA_MAJOR_VERSION=10
-ENV CUDA_MINOR_VERSION=1
-ENV CUDA_PATCH_VERSION=243
+ENV CUDA_MINOR_VERSION=2
+ENV CUDA_PATCH_VERSION=89
 ENV CUDA_VERSION=$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION.$CUDA_PATCH_VERSION
 ENV CUDA_PKG_VERSION=$CUDA_MAJOR_VERSION-$CUDA_MINOR_VERSION=$CUDA_VERSION-1
 ENV CUDNN_VERSION=7.6.5.32
-ENV CUBLAS_VERSION=10.2.1.243
+ENV CUBLAS_VERSION=10.2.2.89
 LABEL com.nvidia.volumes.needed="nvidia_driver"
 LABEL com.nvidia.cuda.version="${CUDA_VERSION}"
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_TAG=staging
-FROM nvidia/cuda:11.0.3-cudnn8-devel-ubuntu18.04 AS nvidia
+FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04 AS nvidia
 FROM gcr.io/kaggle-images/rstats:${BASE_TAG}
 ARG ncpus=1
 
@@ -10,10 +10,13 @@ COPY --from=nvidia /etc/apt/sources.list.d/cuda.list /etc/apt/sources.list.d/
 COPY --from=nvidia /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/
 COPY --from=nvidia /etc/apt/trusted.gpg /etc/apt/trusted.gpg.d/cuda.gpg
 
-ENV CUDA_MAJOR_VERSION=11
-ENV CUDA_MINOR_VERSION=0
-ENV CUDA_PKG_VERSION=$CUDA_MAJOR_VERSION-$CUDA_MINOR_VERSION
-ENV CUDNN_VERSION=8.0.5.39
+ENV CUDA_MAJOR_VERSION=10
+ENV CUDA_MINOR_VERSION=1
+ENV CUDA_PATCH_VERSION=243
+ENV CUDA_VERSION=$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION.$CUDA_PATCH_VERSION
+ENV CUDA_PKG_VERSION=$CUDA_MAJOR_VERSION-$CUDA_MINOR_VERSION=$CUDA_VERSION-1
+ENV CUDNN_VERSION=7.6.5.32
+ENV CUBLAS_VERSION=10.2.1.243
 LABEL com.nvidia.volumes.needed="nvidia_driver"
 LABEL com.nvidia.cuda.version="${CUDA_VERSION}"
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
@@ -36,12 +39,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       cuda-nvml-dev-$CUDA_PKG_VERSION \
       cuda-minimal-build-$CUDA_PKG_VERSION \
       cuda-command-line-tools-$CUDA_PKG_VERSION \
-      libcudnn8=$CUDNN_VERSION-1+cuda$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION \
-      libcudnn8-dev=$CUDNN_VERSION-1+cuda$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION \
-      libcublas-$CUDA_PKG_VERSION \
-      libcublas-dev-$CUDA_PKG_VERSION \
-      libnccl2=2.11.4-1+cuda$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION \
-      libnccl-dev=2.11.4-1+cuda$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION && \
+      libcudnn7=$CUDNN_VERSION-1+cuda$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION \
+      libcudnn7-dev=$CUDNN_VERSION-1+cuda$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION \
+      libcublas10=$CUBLAS_VERSION-1 \
+      libcublas-dev=$CUBLAS_VERSION-1 \
+      libnccl2=2.5.6-1+cuda$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION \
+      libnccl-dev=2.5.6-1+cuda$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION && \
     ln -s /usr/local/cuda-$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION /usr/local/cuda && \
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
     /tmp/clean-layer.sh
@@ -56,7 +59,7 @@ ENV CUDA_HOME=/usr/local/cuda
 ADD ldpaths $R_HOME/etc/ldpaths
 
 # Install tensorflow with GPU support
-RUN R -e 'keras::install_keras(tensorflow = "2.6-gpu")' && \
+RUN R -e 'keras::install_keras(tensorflow = "2.3-gpu")' && \
     rm -rf /tmp/tensorflow_gpu && \
     /tmp/clean-layer.sh
 
@@ -71,7 +74,6 @@ RUN CPATH=/usr/local/cuda/targets/x86_64-linux/include install2.r --error --ncpu
 
 # Torch: install the full package upfront otherwise it will be installed on loading the package which doesn't work for kernels
 # without internet (competitions for example). It will detect CUDA and install the proper version.
-RUN R -e 'install.packages("torch")'
 RUN R -e 'library(torch); install_torch(reinstall = TRUE)'
 
 CMD ["R"]

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -47,6 +47,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       libnccl-dev=2.5.6-1+cuda$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION && \
     ln -s /usr/local/cuda-$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION /usr/local/cuda && \
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
+    # TODO: remove this hack when we move past tensorflow 2.3
+    # https://github.com/tensorflow/tensorflow/issues/38578#issuecomment-760175854
+    ln -sf /usr/local/cuda/lib64/libcudart.so.10.2 /usr/local/cuda/lib64/libcudart.so.10.1 && \
     /tmp/clean-layer.sh
 
 ENV CUDA_HOME=/usr/local/cuda

--- a/package_installs.R
+++ b/package_installs.R
@@ -56,4 +56,4 @@ library(torch)
 install_torch(reinstall = TRUE)
 
 # The R Keras package must be reinstalled after installing it in the python virtualenv.
-install_version("keras", version = "2.6.0", ask=FALSE)
+install_version("keras", version = "2.3.0.0", ask=FALSE)


### PR DESCRIPTION
We can't install this version until the nvidia driver is upgraded on the COS image (https://b.corp.google.com/issues/208428716#comment4).

Let's revert this PR in order to keep the repo clean until we can do this upgrade.

http://b/208428716