### PR TITLE
Install fslr in rstats

### DIFF
--- a/package_installs.R
+++ b/package_installs.R
@@ -34,6 +34,9 @@ install.packages("openNLPmodels.en",
 install_github("davpinto/fastknn")
 install_github("mukul13/rword2vec")
 
+# b/232137539 Removed from RCRAN but required for Neurohacking in R coursera course
+install_github("muschellij2/fslr")
+
 # These signal processing libraries are on CRAN, but they require apt-get dependences that are
 # handled in this image's Dockerfile.
 install.packages("fftw")


### PR DESCRIPTION
The package was archived on RCRAN due to `neurobase` (one of its dependencies) being archived because of:

```
Archived on 2022-04-18 as 'coercion to logical' errors were not corrected in time.
```

Installing directly from GitHub.

http://b/232137539