### PR TITLE
Handle errors in jupyterlab-lsp test

### DIFF
--- a/tests/test_jupyterlab-lsp.R
+++ b/tests/test_jupyterlab-lsp.R
@@ -11,19 +11,22 @@ test_that("jupyterlab-lsp is installed", {
 		
 		code <- 0
 		for (x in 1:5) {
-			Sys.sleep(5)
-
 			# Ping LSP endpoint, verify 200 response
-			response <- GET("http://127.0.0.1:9999/lsp/status")
-			code <- status_code(response)
+			print("ping lsp server...")
+			response <- try(GET("http://localhost:9999/lsp/status"))
+			if (class(response) == "response")
+				code <- status_code(response)
+
 			if (code == 200) {
-			  break
+				break
 			}
+
+			Sys.sleep(5)
 		}
 		expect_equal(code, 200)
 
 		# Kill the server
-		pid <- system("ps -ef | grep jupyter | grep 9999 | awk '{print $2}'")
+		pid <- system("ps -ef | grep jupyter | grep 9999 | awk '{print $2}' | head -n 1", intern = TRUE)
 		tools::pskill(pid)
 	}, NA) # expect no error to be thrown
 })


### PR DESCRIPTION
Turns out this was still failing because lots of http requests throw errors. Now we handle those errors, check that we got a response back, and that it is a 200 code.

I also noticed that the system command was returning the exit code, not the pid, so I fixed that.