### PR TITLE
Remove fslr package because of a broken dependency

### DIFF
--- a/package_installs.R
+++ b/package_installs.R
@@ -34,9 +34,6 @@ install.packages("openNLPmodels.en",
 install_github("davpinto/fastknn")
 install_github("mukul13/rword2vec")
 
-# b/232137539 Removed from RCRAN but required for Neurohacking in R coursera course
-install_github("muschellij2/fslr")
-
 # These signal processing libraries are on CRAN, but they require apt-get dependences that are
 # handled in this image's Dockerfile.
 install.packages("fftw")

--- a/tests/test_imports.R
+++ b/tests/test_imports.R
@@ -15,7 +15,6 @@ test_that("imports", {
     Library("digest")
     Library("dplyr")
     Library("fftw")
-    Library("fslr")
     Library("ggforce")
     Library("ggrepel")
     Library("gtable")


### PR DESCRIPTION
The build fails with `ERROR: dependency ‘neurobase’ is not available for package ‘fslr’` (https://ci.kaggle.net/job/kernels/job/docker-rstats/job/main/124/consoleText) for the reason explained in http://b/232137539#comment5

We could decide to install `neurobase` from GitHub (`install_github("muschellij2/neurobase")`) but that package seems too broken (as it was removed from rcran; related bug: https://github.com/muschellij2/neurobase/issues/6).

http://b/234617302