### PR TITLE
Fix tensorflow install with upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN R -e 'reticulate::install_miniconda()'
 ENV RETICULATE_PYTHON=/root/.local/share/r-miniconda/envs/r-reticulate/bin/python
 
 # Tensorflow and Keras
-RUN R -e 'keras::install_keras(tensorflow = "2.6", extra_packages = c("pandas", "numpy", "pycryptodome"), method="conda")'
+RUN R -e 'keras::install_keras(tensorflow = "2.12", extra_packages = c("pandas", "numpy", "pycryptodome"), method="conda")'
 
 # Install kaggle libraries.
 # Do this at the end to avoid rebuilding everything when any change is made.


### PR DESCRIPTION
Hope to fix this error:
```
#12 41.78 ERROR: Could not find a version that satisfies the requirement tensorflow==2.6.* (from versions: 2.12.0rc0, 2.12.0rc1, 2.12.0, 2.12.1, 2.13.0rc0, 2.13.0rc1, 2.13.0rc2, 2.13.0, 2.14.0rc0)

#12 41.78 ERROR: No matching distribution found for tensorflow==2.6.*

#12 42.02 Error: Error installing package(s): "'tensorflow==2.6.*'", "tensorflow-hub", "tensorflow-datasets", "scipy", "requests", "Pillow", "h5py", "pandas", "pydot", "numpy", "pycryptodome"
```