### PR TITLE
Add "UniversalCVI" package

### DIFF
--- a/package_installs.R
+++ b/package_installs.R
@@ -65,3 +65,7 @@ install.packages(c('collections', 'languageserver'), dependencies=TRUE)
 # The tfhub package is added to the rcran image.
 library(tfhub)
 install_tfhub()
+
+
+# This cluster validity index package is on CRAN.
+install.packages("UniversalCVI")


### PR DESCRIPTION
UniversalCVI is a new package on CRAN. It can be used for checking the accuracy of a clustering result with known classes, computing cluster validity indices, and generating plots for comparing them.