### PR TITLE
Do not delete old unversioned images in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,16 +111,6 @@ pipeline {
         '''
       }
     }
-
-    stage('Delete Old Unversioned Images') {
-      steps {
-        sh '''#!/bin/bash
-          set -exo pipefail
-          gcloud container images list-tags gcr.io/kaggle-images/rstats --filter="NOT tags:v* AND timestamp.datetime < -P6M" --format='get(digest)' --limit 100 | xargs -I {} gcloud container images delete gcr.io/kaggle-images/rstats@{} --quiet --force-delete-tags
-          gcloud container images list-tags gcr.io/kaggle-private-byod/rstats --filter="NOT tags:v* AND timestamp.datetime < -P6M" --format='get(digest)' --limit 100 | xargs -I {} gcloud container images delete gcr.io/kaggle-private-byod/rstats@{} --quiet --force-delete-tags
-        '''
-      }
-    }
   }
 
   post {


### PR DESCRIPTION
Use new Artifact Registry cleanup policies feature instead.

http://b/321030221