### PR TITLE
fix: add missing python3-packaging RECORD file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,24 @@ ARG PYTHON_VERSION=3.10
 
 ADD clean-layer.sh  /tmp/clean-layer.sh
 
-# Install Python 
-RUN apt-get install -y software-properties-common && \
+# pip >= 26 pulls in wheel 0.46+, which depends on packaging>=24.0. The base
+# image has packaging 24.0 installed via apt without a RECORD file (Debian
+# policy), so pip fails with "uninstall-no-record-file" when trying to upgrade
+# it. Generate the missing RECORD so pip can manage the package normally.
+# TODO: Consider moving this fix upstream into the rcran base image.
+ADD fix-packaging-record.sh /tmp/fix-packaging-record.sh
+
+# Install Python
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa -y && \
     apt-get update && \
     echo "MOD: python${PYTHON_VERSION}" && \
     apt-get install -y python${PYTHON_VERSION} && \
     ln -sf /usr/bin/python${PYTHON_VERSION} /usr/bin/python && \
+    /tmp/fix-packaging-record.sh && \
     curl -sS https://bootstrap.pypa.io/get-pip.py | python && \
-    /tmp/clean-layer.sh    
+    /tmp/clean-layer.sh
 
 RUN apt-get update && \
     apt-get install -y libzmq3-dev default-jdk && \

--- a/fix-packaging-record.sh
+++ b/fix-packaging-record.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Generate a missing RECORD file for the apt-installed python3-packaging.
+#
+# Debian/Ubuntu intentionally omit RECORD files from apt-managed Python
+# packages. pip >= 26 needs a RECORD to uninstall a package, so it refuses
+# to upgrade packaging with "uninstall-no-record-file". This script creates
+# the RECORD so pip can replace the apt version cleanly.
+
+set -euo pipefail
+
+dist_info=$(python3 -c "
+import importlib.metadata
+print(importlib.metadata.distribution('packaging')._path)
+")
+
+cd "$(dirname "$dist_info")"
+find packaging packaging-*.dist-info -type f \
+    | sed 's/$/,,/' \
+    > "$dist_info/RECORD"
+
+echo "Generated RECORD for python3-packaging at $dist_info/RECORD"


### PR DESCRIPTION
BUG=b/488135217

Some python dependencies in the base image get installed with `apt` instead of `pip`. This confuses some of the `pip` commands here since those dependencies are missing `RECORD` files. 

Alternatively, we could update the base image to install with `pip` (or better, `uv`). But patching the bug here keeps the changes scoped to the ci pipeline that's actually broken. 