### PR TITLE
fix: remove hrbrthemes from R import tests

### DIFF
--- a/tests/test_imports.R
+++ b/tests/test_imports.R
@@ -19,7 +19,6 @@ test_that("imports", {
     Library("ggforce")
     Library("ggrepel")
     Library("gtable")
-    Library("hrbrthemes")
     Library("imager")
     Library("knitr")
     Library("labeling")


### PR DESCRIPTION
BUG=b/488135217

this was removed from the base image `docker-rcran` in https://github.com/Kaggle/docker-rcran/pull/85. So it needs to be removed here as well.