### PR TITLE
fix: replace '/' with '-' in git branch names

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,8 +17,8 @@ pipeline {
     MATTERMOST_CHANNEL = sh(returnStdout: true, script: "if [[ \"${GIT_BRANCH}\" == \"main\" ]]; then echo \"#kernelops\"; else echo \"#builds\"; fi").trim()
     // See b/152450512
     GITHUB_PAT = credentials('github-pat')
-    PRETEST_TAG = sh(returnStdout: true, script: "if [[ \"${GIT_BRANCH}\" == \"main\" ]]; then echo \"ci-pretest\"; else echo \"${GIT_BRANCH}-pretest\"; fi").trim()
-    STAGING_TAG = sh(returnStdout: true, script: "if [[ \"${GIT_BRANCH}\" == \"main\" ]]; then echo \"staging\"; else echo \"${GIT_BRANCH}-staging\"; fi").trim()
+    PRETEST_TAG = sh(returnStdout: true, script: "if [[ \"${GIT_BRANCH}\" == \"main\" ]]; then echo \"ci-pretest\"; else echo \"${GIT_BRANCH}-pretest\" | tr '/' '-'; fi").trim()
+    STAGING_TAG = sh(returnStdout: true, script: "if [[ \"${GIT_BRANCH}\" == \"main\" ]]; then echo \"staging\"; else echo \"${GIT_BRANCH}-staging\" | tr '/' '-'; fi").trim()
   }
 
   stages {

--- a/push
+++ b/push
@@ -46,7 +46,7 @@ while :; do
     shift
 done
 
-LABEL=${1:-testing}
+LABEL=$(echo "${1:-testing}" | sed 's/[^a-zA-Z0-9._-]/-/g')
 
 if [[ -n "$SOURCE_IMAGE_TAG_OVERRIDE" ]]; then
     SOURCE_IMAGE_TAG="$SOURCE_IMAGE_TAG_OVERRIDE"


### PR DESCRIPTION
BUG=b/488135217

docker tags can't have `/`, but we use the git branch name in docker tags in our ci jobs. this replaces `/` in git branch names with `-`.