### PR TITLE
fix: pin torch R package to 0.13.0 for CUDA 11.7 compatibility

### DIFF
--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -72,9 +72,9 @@ RUN CPATH=/usr/local/cuda/targets/x86_64-linux/include install2.r --error --ncpu
 
 # Torch: install the full package upfront otherwise it will be installed on loading the package which doesn't work for kernels
 # without internet (competitions for example). It will detect CUDA and install the proper version.
-# Make Torch think we use CUDA 11.8 (https://github.com/mlverse/torch/issues/807)
+# Pin torch to 0.13.0 (libtorch 2.0.1), the last version supporting CUDA 11.7.
 ENV CUDA=11.7
-RUN R -e 'install.packages("torch")'
+RUN R -e 'install.packages("remotes"); remotes::install_version("torch", version = "0.13.0")'
 RUN R -e 'library(torch); install_torch()'
 
 CMD ["R"]


### PR DESCRIPTION
a hotfix to momentarily avoid: https://github.com/Kaggle/docker-rstats/pull/218

PyTorch 2.8 dropped CUDA 11.7 support, causing install_torch() to fail with HTTP 403. Pin torch to 0.13.0 (libtorch 2.0.1), the last version that ships cu117 binaries, avoiding a full CUDA stack upgrade.